### PR TITLE
Add transform-decorators-legacy plugin to package.json

### DIFF
--- a/episode1/package.json
+++ b/episode1/package.json
@@ -77,6 +77,9 @@
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(js|jsx)$"
   },
   "babel": {
+    "plugins": [
+      "transform-decorators-legacy"
+    ],
     "presets": [
       "react-app"
     ]


### PR DESCRIPTION
Specifies the decorators plugin in the `.babelrc` config, as per [plugin docs](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy#installation--usage)

Otherwise, Babel fails to compile after `npm install` and `npm start`.

```
Failed to compile.

Error in ./src/components/ContactsApp.js
Syntax error: Unexpected token (7:0)

   5 | import './ContactsApp.css';
   6 | 
>  7 | @LoadingHOC('contacts')
     | ^
```

I noticed in the YouTube video that you have a separate `.babelrc` file in the root, which wasn't included in this repo.